### PR TITLE
fix/monitor-csv: add information for progress bar

### DIFF
--- a/src/ImportBundle/Step/CsvExtractorStep.php
+++ b/src/ImportBundle/Step/CsvExtractorStep.php
@@ -47,9 +47,21 @@ class CsvExtractorStep extends AbstractConfigurableStep implements IterableStepI
         $this->iterator->next();
     }
 
+    public function count(ProcessState $state)
+    {
+        $file = $state->getOptions()['filepath'];
+
+        return (int) `cat $file | wc -l`;
+    }
+
     public function valid(ProcessState $state)
     {
         return $this->iterator->valid();
+    }
+
+    public function getProgress(ProcessState $state)
+    {
+        return $this->iterator->key();
     }
 
     public function describe(ProcessState $state)

--- a/tests/ImportBundle/Step/CsvExtractorStepTest.php
+++ b/tests/ImportBundle/Step/CsvExtractorStepTest.php
@@ -138,4 +138,47 @@ class CsvExtractorStepTest extends TestCase
     {
         $this->assertFalse(CsvExtractorStep::isDeprecated());
     }
+
+    public function testCount()
+    {
+        $filepath = sprintf('/tmp/%s.csv', md5(__CLASS__));
+        file_put_contents(
+            $filepath,
+            'first line'.PHP_EOL.'second line'.PHP_EOL
+        );
+
+        $state = new ProcessState(
+            [],
+            $logger = $this->createMock(LoggerInterface::class),
+            $this->createMock(StepRunner::class)
+        );
+        $state->setOptions([
+            'filepath' => $filepath,
+        ]);
+
+        $this->assertEquals(2, $this->step->count($state));
+    }
+
+    public function testGetProgress()
+    {
+        $iterator = new \ArrayIterator([ 1 => ['color' => 'red'], 2 => ['color' => 'blue']]);
+        $this->extractor
+            ->expects($this->once())
+            ->method('extract')
+            ->with('file.csv', ';', null)
+            ->willReturn($iterator);
+
+        $state = new ProcessState(
+            [],
+            $this->createMock(LoggerInterface::class),
+            $this->createMock(StepRunner::class)
+        );
+        $state->setOptions(['filepath' => 'file.csv', 'delimiter' => ';', 'colums_names' => null]);
+
+        $this->step->execute($state);
+
+        $this->step->next($state);
+
+        $this->assertEquals(2, $this->step->getProgress($state));
+    }
 }


### PR DESCRIPTION
#### Description

Fourni au système les informations sur la progression de l'itération d'un csv afin que celui-ci puisse correctement afficher la progress bar

#### Destination

Version 0.3