### PR TITLE
Pour optimiser la mémoire on ne stocke plus les entité dans le batch du persister

### DIFF
--- a/src/ImportBundle/Persister/DoctrinePersister.php
+++ b/src/ImportBundle/Persister/DoctrinePersister.php
@@ -16,7 +16,7 @@ use Doctrine\ORM\EntityManagerInterface;
 class DoctrinePersister implements PersisterInterface
 {
     private $em;
-    private $batch = [];
+    private $batch = 0;
 
     private $whiteList = [];
     private $blackList = [];
@@ -28,11 +28,13 @@ class DoctrinePersister implements PersisterInterface
 
     public function persist($entity, $batchCount = 20, $whiteList = [], $blackList = [])
     {
-        $this->batch[] = $entity;
+        ++$this->batch;
         $this->whiteList = $whiteList;
         $this->blackList = $blackList;
 
-        if (count($this->batch) >= $batchCount) {
+        $this->em->persist($entity);
+
+        if ($this->batch >= $batchCount) {
             $this->writeBatch();
         }
     }
@@ -44,14 +46,10 @@ class DoctrinePersister implements PersisterInterface
 
     private function writeBatch()
     {
-        foreach ($this->batch as $item) {
-            $this->em->persist($item);
-        }
-
         $this->em->flush();
         $this->clear();
 
-        $this->batch = [];
+        $this->batch = 0;
     }
 
     private function clear()

--- a/tests/ImportBundle/Persister/DoctrinePersisterTest.php
+++ b/tests/ImportBundle/Persister/DoctrinePersisterTest.php
@@ -51,7 +51,7 @@ class DoctrinePersisterTest extends TestCase
         $this->persister->persist($entity);
 
         $this->em
-            ->expects($this->once())
+            ->expects($this->never())
             ->method('persist')
             ->with($entity);
 
@@ -68,7 +68,7 @@ class DoctrinePersisterTest extends TestCase
         $this->persister->persist($entity, 20, [Product::class], []);
 
         $this->em
-            ->expects($this->once())
+            ->expects($this->never())
             ->method('persist')
             ->with($entity);
 
@@ -88,7 +88,7 @@ class DoctrinePersisterTest extends TestCase
         $this->expectExceptionMessage('unsupported blacklist');
 
         $this->em
-            ->expects($this->once())
+            ->expects($this->never())
             ->method('persist')
             ->with($entity);
 


### PR DESCRIPTION
#### Description
Pour optimiser la mémoire on ne stocke plus les entité dans le batch du persister

#### Destination
Version 0.3