### PR TITLE
Je veux pouvoir boucler sur mon traitement avec une limite de temps/itération

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,7 @@ test-integration: db
 	php tests/App/console.php process:run -vv -- demo_unique_filter
 	php tests/App/console.php process:run -vv -- demo_filter_step
 	php tests/App/console.php process:run -vv -- demo_validate_object
+	php tests/App/console.php process:run -vv -- demo_while
 	php tests/App/console.php process:run -vv --context node=album --context filepath=./tests/fixtures/xml/album.xml -- import_xml
 
 import-xml-debug:

--- a/doc/list-step.md
+++ b/doc/list-step.md
@@ -4,6 +4,7 @@
 | [Darkilliant\ImportBundle\Step\CsvExtractorStep](./step/csv_extractor.md)                       |   OUI    | extraire chaque ligne d'un fichier csv sous forme d'un tableau php            |
 | [Darkilliant\ImportBundle\Step\XmlExtractorStep](./step/xml_extractor.md)                       |   OUI    | extraire chaque noeud xml d'un type particulier sous forme d'un tableau php   |
 | [Darkilliant\ProcessBundle\Step\IterateArrayStep](./step/iterate_array.md)                      |   OUI    | parcourir un tableau php                                                      |
+| [Darkilliant\ImportBundle\Step\WhileStep](./step/while_step.md)                                 |   OUI    | Boucle sur les steps qu'il exécute j'usqu'a un max d'iteration ou de temps    |
 | [Darkilliant\ImportBundle\Step\MappingTransformerStep](./step/mapping_transformer.md)           |   NON    | transformer un tableau php et le valider                                      |
 | [Darkilliant\ImportBundle\Step\LoadObjectNormalizedStep](./step/load_object_normalized.md)      |   NON    | convertir un tableau php en entité doctrine avec ses relations                |
 | [Darkilliant\ImportBundle\Step\DoctrinePersisterStep](./step/doctrine_persister.md)             |   NON    | persister une entité doctrine en bdd                                          |
@@ -17,6 +18,7 @@
 | [Darkilliant\ProcessBundle\Step\FilterStep](./step/filter_step.md)                              |   NON    | Filter les données dans le pipe                                               |
 | [Darkilliant\ImportBundle\Step\TransformStep](./step/transform_step.md)                         |   NON    | Transforme et valide les donnés dans le pipe                                  |
 | [Darkilliant\ImportBundle\Step\MappingStep](./step/mapping_step.md)                             |   NON    | Permet de changer la structure d'un tableau d'un format vers un autre         |
+
 
 Si vous désirez ajouter une miro tache,<br>
 il vous suffit de déclarer un service en public dont sa classe hérite de `Darkilliant\ProcessBundle\Step\AbstractConfigurableStep`.<br>

--- a/doc/step/while_step.md
+++ b/doc/step/while_step.md
@@ -1,0 +1,25 @@
+#### Darkilliant\ProcessBundle\Step\WhileStep
+
+##### Rôle 
+
+boucle les des steps jusqu'a atteindre un nombre d'itération ou de temps d'éxécution définit par sa config.<br>
+En règle général, on peut coupler cela avec un supervisor pour le relancer quand il s'arête afin d'avoir une bonne gestion de la mémoire.
+
+##### Options
+
+| Nom                  | Description                                         |
+|----------------------|-----------------------------------------------------|
+| max_iteration        | limite du nombre d'itération avant de tout stopper  |
+| max_time             | limite du nombre de temps avant de tout stopper     |
+| sleep_between        | temp à attendre entre les itération (défaut: 1)     |
+
+##### Examples
+
+```yaml
+service: 'Darkilliant\ProcessBundle\Step\WhileStep'
+options:
+    max_iteration: 10
+    max_time: 60 # time in seconds
+    sleep_between: 1 # time in seconds
+    progress_bar: true
+```

--- a/src/ProcessBundle/Step/WhileStep.php
+++ b/src/ProcessBundle/Step/WhileStep.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Darkilliant\ProcessBundle\Step;
+
+use Darkilliant\ProcessBundle\State\ProcessState;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class WhileStep extends AbstractConfigurableStep implements IterableStepInterface
+{
+    public $count = 0;
+    private $startedAt;
+    private $timeElasped = 0;
+
+    public function configureOptionResolver(OptionsResolver $resolver): OptionsResolver
+    {
+        $resolver->setRequired(['sleep_between', 'max_time', 'max_iteration']);
+        $resolver->setDefault('sleep_between', 1);
+        $resolver->setDefault('max_time', null);
+        $resolver->setDefault('max_iteration', null);
+
+        return parent::configureOptionResolver($resolver);
+    }
+
+    public function execute(ProcessState $state)
+    {
+        if (null === $state->getOptions()['max_time'] && null === $state->getOptions()['max_iteration']) {
+            $state->error('please set max_time or max_iteration');
+            $state->markFail();
+
+            return;
+        }
+
+        $state->info('while', $state->getOptions());
+
+        $this->count = 0;
+        $this->startedAt = time();
+        $this->timeElasped = 0;
+    }
+
+    public function valid(ProcessState $state)
+    {
+        if (null !== $state->getOptions()['max_time'] && $this->timeElasped >= $state->getOptions()['max_time']) {
+            return false;
+        }
+
+        if (null !== $state->getOptions()['max_iteration'] && $this->count >= $state->getOptions()['max_iteration']) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public function next(ProcessState $state)
+    {
+        $state->getLogger()->debug('next on while', [
+            'count' => $this->count,
+            'started_at' => $this->startedAt,
+            'time_elapsed' => $this->timeElasped,
+        ]);
+
+        $this->timeElasped = time() - $this->startedAt;
+        ++$this->count;
+        sleep($state->getOptions()['sleep_between']);
+    }
+
+    public function count(ProcessState $state)
+    {
+        return $state->getOptions()['max_iteration'] ?: $state->getOptions()['max_time'] ?: 0;
+    }
+
+    public function getProgress(ProcessState $state)
+    {
+        if ($state->getOptions()['max_iteration']) {
+            return $this->count;
+        }
+
+        if ($state->getOptions()['max_time']) {
+            return $this->timeElasped;
+        }
+
+        return 0;
+    }
+}

--- a/tests/App/config/process/demo_while.yml
+++ b/tests/App/config/process/demo_while.yml
@@ -1,0 +1,16 @@
+darkilliant_process:
+    process:
+        demo_while:
+            steps:
+                -
+                    service: Darkilliant\ProcessBundle\Step\WhileStep
+                    options:
+                        max_iteration: 10
+                        sleep_between: 0
+                        progress_bar: true
+                -
+                    service: Darkilliant\ProcessBundle\Step\PredefinedDataStep
+                    options: { data: 'et de un...' }
+                -
+                    service: Darkilliant\ProcessBundle\Step\DebugStep
+                    options: []

--- a/tests/ProcessBundle/Step/WhileStepTest.php
+++ b/tests/ProcessBundle/Step/WhileStepTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Darkilliant\ProcessBundle\Step;
+
+use Darkilliant\ProcessBundle\Runner\StepRunner;
+use Darkilliant\ProcessBundle\State\ProcessState;
+use Darkilliant\ProcessBundle\Step\WhileStep;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Bridge\PhpUnit\ClockMock;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+class WhileStepTest extends TestCase
+{
+    /** @var WhileStep */
+    private $step;
+
+    public function setUp()
+    {
+        $this->step = new WhileStep();
+    }
+
+    public static function setUpBeforeClass()
+    {
+        ClockMock::register(WhileStep::class);
+        ClockMock::withClockMock(true);
+    }
+
+    public function testConfigureOptions()
+    {
+        $optionResolver = $this->createMock(OptionsResolver::class);
+
+        $this->assertInstanceOf(
+            OptionsResolver::class,
+            $this->step->configureOptionResolver($optionResolver)
+        );
+    }
+
+    public function testExecute()
+    {
+        $state = new ProcessState(
+            [],
+            $logger = $this->createMock(LoggerInterface::class),
+            $stepRunner = $this->createMock(StepRunner::class)
+        );
+        $state->setOptions($options = [
+            'max_time' => 60,
+            'max_iteration' => 10,
+            'sleep_between' => 1,
+        ]);
+
+        $logger
+            ->expects($this->once())
+            ->method('log')
+            ->with('info', 'while', $options);
+
+        $this->step->execute($state);
+    }
+
+    public function testResultFailWhenNoMaxTimeNoMaxIteration()
+    {
+        $state = new ProcessState(
+            [],
+            $logger = $this->createMock(LoggerInterface::class),
+            $stepRunner = $this->createMock(StepRunner::class)
+        );
+        $state->setOptions($options = [
+            'max_time' => null,
+            'max_iteration' => null,
+            'sleep_between' => 1,
+        ]);
+
+        $logger
+            ->expects($this->once())
+            ->method('log')
+            ->with('error', 'please set max_time or max_iteration', []);
+
+        $this->step->execute($state);
+
+        $this->assertEquals(ProcessState::RESULT_KO, $state->getResult());
+    }
+
+    public function testCountWithMaxTime()
+    {
+        $state = new ProcessState(
+            [],
+            $logger = $this->createMock(LoggerInterface::class),
+            $stepRunner = $this->createMock(StepRunner::class)
+        );
+        $state->setOptions($options = [
+            'max_time' => 60,
+            'max_iteration' => null,
+            'sleep_between' => 1,
+        ]);
+
+        $this->step->execute($state);
+        $this->assertEquals(60, $this->step->count($state));
+    }
+
+    public function testCountWithMaxIteration()
+    {
+        $state = new ProcessState(
+            [],
+            $logger = $this->createMock(LoggerInterface::class),
+            $stepRunner = $this->createMock(StepRunner::class)
+        );
+        $state->setOptions($options = [
+            'max_time' => null,
+            'max_iteration' => 10,
+            'sleep_between' => 1,
+        ]);
+
+        $this->step->execute($state);
+        $this->assertEquals(10, $this->step->count($state));
+    }
+
+    public function testProgressWithMaxTime()
+    {
+        $state = new ProcessState(
+            [],
+            $logger = $this->createMock(LoggerInterface::class),
+            $stepRunner = $this->createMock(StepRunner::class)
+        );
+        $state->setOptions($options = [
+            'max_time' => 60,
+            'max_iteration' => null,
+            'sleep_between' => 1,
+        ]);
+
+        $this->step->execute($state);
+        ClockMock::sleep(5);
+        $this->step->next($state);
+        $this->assertEquals(5, $this->step->getProgress($state));
+    }
+
+    public function testProgressWithMaxIteration()
+    {
+        $state = new ProcessState(
+            [],
+            $logger = $this->createMock(LoggerInterface::class),
+            $stepRunner = $this->createMock(StepRunner::class)
+        );
+        $state->setOptions($options = [
+            'max_time' => null,
+            'max_iteration' => 10,
+            'sleep_between' => 1,
+        ]);
+
+        $this->step->execute($state);
+        $this->step->next($state);
+        $this->assertEquals(1, $this->step->getProgress($state));
+    }
+
+    public function testGetProgressWhenNoMaxTimeNoMaxIteration()
+    {
+        $state = new ProcessState(
+            [],
+            $logger = $this->createMock(LoggerInterface::class),
+            $stepRunner = $this->createMock(StepRunner::class)
+        );
+        $state->setOptions($options = [
+            'max_time' => null,
+            'max_iteration' => null,
+            'sleep_between' => 1,
+        ]);
+
+        $this->assertEquals(0, $this->step->getProgress($state));
+    }
+
+    public function provideValid()
+    {
+        // Time
+        yield [[
+            'options' => ['max_time' => 60, 'max_iteration' => null, 'sleep_between' => 1],
+            'sleep' => 1,
+            'valid' => true,
+        ]];
+        yield [[
+            'options' => ['max_time' => 60, 'max_iteration' => null, 'sleep_between' => 1],
+            'sleep' => 61,
+            'valid' => false,
+        ]];
+
+        // Iteration
+        yield [[
+            'options' => ['max_time' => null, 'max_iteration' => 2, 'sleep_between' => 1],
+            'sleep' => 0,
+            'valid' => true,
+        ]];
+        yield [[
+            'options' => ['max_time' => null, 'max_iteration' => 1, 'sleep_between' => 1],
+            'sleep' => 0,
+            'valid' => false,
+        ]];
+
+        // Time before iteration when valid before
+        yield [[
+            'options' => ['max_time' => 0, 'max_iteration' => 2, 'sleep_between' => 1],
+            'sleep' => 0,
+            'valid' => false,
+        ]];
+    }
+
+    /**
+     * @dataProvider provideValid
+     */
+    public function testValid($params)
+    {
+        list ($options, $sleep, $isValid) = array_values($params);
+
+        $state = new ProcessState(
+            [],
+            $logger = $this->createMock(LoggerInterface::class),
+            $stepRunner = $this->createMock(StepRunner::class)
+        );
+        $state->setOptions($options);
+
+        $this->step->execute($state);
+        ClockMock::sleep($sleep);
+        $this->step->next($state);
+
+        $this->assertEquals($isValid, $this->step->valid($state));
+    }
+}


### PR DESCRIPTION
#### Description
Je veux pouvoir boucler sur mon traitement avec une limite de temps/itération

Il est désormait possible d'éxécuter une action en boucle (ex: récupèrer des fichier sur un ftp) en appliquant bien sur une limite de  temps et/ou d'itération afin d'évitier que la mémoire d'un long process php monte et diminue le flux.

#### Destination

Version 0.4

