### PR TITLE
fix/doctrine-persister: passer au persister la liste des entité à clear

### DIFF
--- a/src/ImportBundle/Step/DoctrinePersisterStep.php
+++ b/src/ImportBundle/Step/DoctrinePersisterStep.php
@@ -19,8 +19,9 @@ class DoctrinePersisterStep extends AbstractConfigurableStep
 
     public function configureOptionResolver(OptionsResolver $resolver): OptionsResolver
     {
-        $resolver->setRequired(['batch_count', 'whitelist_clear']);
+        $resolver->setRequired(['batch_count', 'whitelist_clear', 'blacklist_clear']);
         $resolver->setDefault('whitelist_clear', []);
+        $resolver->setDefault('blacklist_clear', []);
 
         return parent::configureOptionResolver($resolver);
     }
@@ -28,7 +29,12 @@ class DoctrinePersisterStep extends AbstractConfigurableStep
     public function execute(ProcessState $state)
     {
         if (!$state->isDryRun()) {
-            $this->persister->persist($state->getData(), $state->getOptions()['batch_count']);
+            $this->persister->persist(
+                $state->getData(),
+                $state->getOptions()['batch_count'],
+                $state->getOptions()['whitelist_clear'],
+                $state->getOptions()['blacklist_clear']
+            );
 
             $this->describe($state);
         }

--- a/tests/ImportBundle/Step/DoctrinePersisterStepTest.php
+++ b/tests/ImportBundle/Step/DoctrinePersisterStepTest.php
@@ -45,13 +45,17 @@ class DoctrinePersisterStepTest extends TestCase
             $this->createMock(LoggerInterface::class),
             $this->createMock(StepRunner::class)
         );
-        $state->setOptions(['batch_count' => 20]);
+        $state->setOptions([
+            'batch_count' => 20,
+            'whitelist_clear' => [],
+            'blacklist_clear' => []
+        ]);
         $state->setData(new \stdClass());
 
         $this->persister
             ->expects($this->once())
             ->method('persist')
-            ->with(new \stdClass());
+            ->with(new \stdClass(), 20, [], []);
 
         $this->step->execute($state);
     }


### PR DESCRIPTION
#### Description

fix/doctrine-persister: passer au persister la liste des entité à clear

#### Version

0.3