### PR TITLE
Je veux un contexte de boucle ainsi qu'un accès plus simple aux options/context

### DIFF
--- a/src/ProcessBundle/Runner/StepRunner.php
+++ b/src/ProcessBundle/Runner/StepRunner.php
@@ -149,7 +149,7 @@ class StepRunner
                     return false;
                 }
             } catch (\Throwable $exception) {
-                $processState->setContext('current_error', $exception);
+                $processState->setContext('current_error', $exception, false);
                 $processState->getLogger()->error('fail step', array_merge([
                     'message' => $exception->getMessage(),
                     'step' => $step->getService(),
@@ -204,6 +204,7 @@ class StepRunner
             $this->notifier->onStartIterableProcess($processState, $service);
 
             $iterator = $processState->getIterator();
+            $loopContext = $processState->getLoopContext();
 
             $count = $service->count($processState);
 
@@ -232,6 +233,7 @@ class StepRunner
                 $isSuccessful = $this->runSteps($processState, $step->getChildren());
                 $processState->setIterator($iterator);
                 $processState->setOptions($options);
+                $processState->setLoopContext($loopContext);
 
                 if ($isSuccessful) {
                     $service->onSuccessLoop($processState);
@@ -260,10 +262,10 @@ class StepRunner
                     return false;
                 }
             } catch (\Exception $exception) {
-                $processState->getLogger()->error('fail step', array_merge([
+                $processState->error('fail step', [
                     'message' => $exception->getMessage(),
                     'step' => $step->getService(),
-                ], $processState->getRawContext()));
+                ]);
 
                 return false;
             }

--- a/src/ProcessBundle/State/ProcessState.php
+++ b/src/ProcessBundle/State/ProcessState.php
@@ -17,7 +17,9 @@ class ProcessState extends AbstractLogger
     const RESULT_EXIT = 5;
 
     private $data;
-    private $context;
+    private $loopContext;
+    private $logContext = [];
+    private $context = [];
     private $options = [];
     private $logger;
     private $result;
@@ -65,9 +67,9 @@ class ProcessState extends AbstractLogger
     /**
      * @return mixed
      */
-    public function getContext($key)
+    public function getContext($key, $default = null)
     {
-        return $this->context[$key];
+        return $this->context[$key] ?? $default;
     }
 
     public function getLoop()
@@ -78,6 +80,7 @@ class ProcessState extends AbstractLogger
     public function noLoop()
     {
         $this->loop = null;
+        $this->loopContext = null;
     }
 
     public function loop(int $index, int $count, bool $last)
@@ -94,12 +97,27 @@ class ProcessState extends AbstractLogger
         return (bool) $this->loop;
     }
 
-    /**
-     * @param mixed $context
-     */
-    public function setContext($key, $value)
+    public function setContext(string $key, $value, bool $logContext = true)
     {
         $this->context[$key] = $value;
+        if ($logContext) {
+            $this->logContext[$key] = $value;
+        }
+    }
+
+    public function hasContext(string $key): bool
+    {
+        return isset($this->context[$key]);
+    }
+
+    public function setLoopContext($value)
+    {
+        $this->loopContext = $value;
+    }
+
+    public function getLoopContext()
+    {
+        return $this->loopContext;
     }
 
     public function getRawContext(): array
@@ -123,6 +141,11 @@ class ProcessState extends AbstractLogger
         return $this->options;
     }
 
+    public function getOption($name, $default = null)
+    {
+        return $this->options[$name] ?? $default;
+    }
+
     /**
      * @param array $options
      */
@@ -133,9 +156,14 @@ class ProcessState extends AbstractLogger
         return $this;
     }
 
+    public function hasOption(string $name): bool
+    {
+        return isset($this->options[$name]);
+    }
+
     public function log($level, $message, array $context = [])
     {
-        $this->logger->log($level, $message, array_merge($context, $this->context));
+        $this->logger->log($level, $message, array_merge($context, $this->logContext));
     }
 
     public function getResult()

--- a/tests/ProcessBundle/Runner/StepRunnerTest.php
+++ b/tests/ProcessBundle/Runner/StepRunnerTest.php
@@ -235,8 +235,8 @@ class StepRunnerTest extends TestCase
             ->willThrowException(new \Exception());
 
         $this->logger
-            ->expects($this->once())
-            ->method('error');
+            ->expects($this->exactly(4))
+            ->method('log');
 
         // Finalize
         $this->stepRegistry

--- a/tests/ProcessBundle/State/ProcessStateTest.php
+++ b/tests/ProcessBundle/State/ProcessStateTest.php
@@ -114,4 +114,26 @@ class ProcessStateTest extends TestCase
 
         $this->assertEquals('demo', $this->state->getName());
     }
+
+    public function testHasContext()
+    {
+        $this->assertFalse($this->state->hasContext('moi'));
+        $this->state->setContext('moi', 'moi');
+        $this->assertTrue($this->state->hasContext('moi'));
+    }
+
+    public function testHasOption()
+    {
+        $this->assertFalse($this->state->hasOption('moi'));
+        $this->state->setOptions(['moi' => 'moi']);
+        $this->assertTrue($this->state->hasOption('moi'));
+    }
+
+    public function testGetOption()
+    {
+        $this->assertEquals('toi', $this->state->getOption('moi', 'toi'));
+        $this->assertNull($this->state->getOption('moi'));
+        $this->state->setOptions(['moi' => 'moi']);
+        $this->assertEquals('moi', $this->state->getOption('moi'));
+    }
 }


### PR DESCRIPTION
#### Description
Je veux un contexte de boucle ainsi qu'un accès plus simple aux options/context

- Chaque boucle peut disposer d'un context propre pour setter des variables qui lui sont local (pas présente dans les logs non plus) 
- Il est possible de vérifier l'existante d'une option/context et d'obtenir une valeur par défaut si celle-ci n'existe pas
- le contexte de log reprend par défaut le contexte global mais il est désormait possible de ne pas y injecter une variable de context en particulier (pratique avec les objets)

#### Version
0.4

#### TODO
- [X] Il ne faut pas afficher dans les logs la variable de context current_error