### PR TITLE
La résolution dynamique des options au niveau du finalize pose problème quand les donnée ne sont plus dans le pipe

### DIFF
--- a/src/ProcessBundle/Runner/StepRunner.php
+++ b/src/ProcessBundle/Runner/StepRunner.php
@@ -129,7 +129,7 @@ class StepRunner
         $processState->markSuccess();
 
         $service = $this->registry->resolveService($step->getService());
-        $this->configureOptions($service, $step, $processState);
+        $this->configureOptionsWithoutResolve($service, $step, $processState);
         $service->finalize($processState);
 
         if (ProcessState::RESULT_OK !== $processState->getResult()) {
@@ -172,6 +172,13 @@ class StepRunner
                     'context' => $processState->getRawContext(),
                 ]
             )
+        );
+    }
+
+    protected function configureOptionsWithoutResolve(StepInterface $service, ConfigurationStep $step, ProcessState $processState): ProcessState
+    {
+        return $processState->setOptions(
+            $service->configureOptionResolver(new OptionsResolver())->resolve($step->getOptions())
         );
     }
 


### PR DESCRIPTION
#### Description
La résolution dynamique des options au niveau du finalize pose problème quand les donnée ne sont plus dans le pipe

Il à donc fallu ne plus faire cette résolution, si cela pose toujours problème l'accès au options au niveau du finalize sera supprimé afin d'éviter des cas de bugs aléatoire

#### Version
0.4

@wetsharkdev je t'invite à review ce bugfix et à me dire si cela répond au bug que du a rencontré